### PR TITLE
RRD Lots of Type Simplifications 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /docs/build/
 
 .DS_Store
+.vscode
 
 testing.jl

--- a/src/Invariants/GraphRules/domination_rule.jl
+++ b/src/Invariants/GraphRules/domination_rule.jl
@@ -4,6 +4,6 @@ function apply!(
     g::AbstractGraph,
 )
     for v in copy(target_set)  # use copy to avoid modifying set during iteration
-        union!(target_set, neighbors(g, v))
+        union!(target_set, Graphs.neighbors(g, v))
     end
 end

--- a/src/Invariants/GraphRules/zero_forcing_rule.jl
+++ b/src/Invariants/GraphRules/zero_forcing_rule.jl
@@ -8,12 +8,15 @@ function apply!(
 )
     changes_made = true
     iter = 0
-    V = vertices(g)
+
+    # The set of vertices.
+    V = Graphs.vertices(g)
+
     while changes_made && iter < max_iter
         changes_made = false
         for v in V
             if (v in blue)
-                white_neighbors = setdiff(neighbors(g, v), blue)
+                white_neighbors = setdiff(Graphs.neighbors(g, v), blue)
                 if length(white_neighbors) == 1
                     union!(blue, white_neighbors)
                     changes_made = true

--- a/src/Invariants/Invariants.jl
+++ b/src/Invariants/Invariants.jl
@@ -23,7 +23,7 @@ The module allows for the computation of complex graph invariants and operations
 ```julia
 julia> using GraphProperties.Invariants
 
-julia> ind_number = compute(IndependenceNumber, my_graph)
+julia> α = compute(IndependenceNumber, my_graph)
 ```
 """
 module Invariants

--- a/src/Invariants/basics/from_graphs.jl
+++ b/src/Invariants/basics/from_graphs.jl
@@ -9,7 +9,7 @@ function compute(
     ::Type{Order},
     g::AbstractGraph{T}
 ) where T <: Integer
-    return nv(g)
+    return Graphs.nv(g)
 end
 
 """
@@ -22,7 +22,7 @@ function compute(
     ::Type{Size},
     g::AbstractGraph{T}
 ) where T <: Integer
-    return ne(g)
+    return Graphs.ne(g)
 end
 
 """
@@ -33,9 +33,9 @@ Return the maximum degree of `g`.
 """
 function compute(
     ::Type{MaximumDegree},
-    g::AbstractGraph{T}
+    g::SimpleGraph{T}
 ) where T <: Integer
-    return maximum(degree(g))
+    return maximum(Graphs.degree(g))
 end
 
 """
@@ -46,9 +46,9 @@ Return the minimum degree of `g`.
 """
 function compute(
     ::Type{MinimumDegree},
-    g::AbstractGraph{T}
+    g::SimpleGraph{T}
  ) where T <: Integer
-    return minimum(degree(g))
+    return minimum(Graphs.degree(g))
 end
 
 """
@@ -59,9 +59,9 @@ Return the average degree of `g`.
 """
 function compute(
     ::Type{AverageDegree},
-    g::AbstractGraph{T}
+    g::SimpleGraph{T}
 ) where T <: Integer
-    return mean(degree(g))
+    return mean(Graphs.degree(g))
 end
 
 """
@@ -72,9 +72,9 @@ Return the diameter of `g`.
 """
 function compute(
     ::Type{Diameter},
-    g::AbstractGraph{T}
+    g::SimpleGraph{T}
 ) where T <: Integer
-    return diameter(g)
+    return Graphs.diameter(g)
 end
 
 """
@@ -85,14 +85,14 @@ Return the radius of `g`.
 """
 function compute(
     ::Type{Radius},
-    g::AbstractGraph{T}
+    g::SimpleGraph{T}
 ) where T <: Integer
-    return radius(g)
+    return Graphs.radius(g)
 end
 
 function compute(
     ::Type{Girth},
-    g::AbstractGraph{T},
+    g::SimpleGraph{T},
 ) where T <: Integer
 
     shortest_cycle = Inf

--- a/src/Invariants/chromatic_colorings/chromatic_number.jl
+++ b/src/Invariants/chromatic_colorings/chromatic_number.jl
@@ -9,7 +9,7 @@ function compute(
     ::Type{ChromaticNumber},
     g::AbstractGraph{T};
     optimizer = HiGHS.Optimizer
-) where T <: Int
+) where T <: Integer
     min_prop_coloring = compute(MinimumProperColoring, g; optimizer=optimizer)
     return length(unique(values(min_prop_coloring.mapping)))
 end

--- a/src/Invariants/chromatic_colorings/chromatic_number.jl
+++ b/src/Invariants/chromatic_colorings/chromatic_number.jl
@@ -7,7 +7,7 @@ Return the chromatic number of `g`.
 """
 function compute(
     ::Type{ChromaticNumber},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer = HiGHS.Optimizer
 ) where T <: Integer
     min_prop_coloring = compute(MinimumProperColoring, g; optimizer=optimizer)

--- a/src/Invariants/chromatic_colorings/proper_colorings.jl
+++ b/src/Invariants/chromatic_colorings/proper_colorings.jl
@@ -1,6 +1,6 @@
 function compute(
     ::Type{MinimumProperColoring},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer = HiGHS.Optimizer
 ) where T <: Integer
 
@@ -9,8 +9,8 @@ function compute(
     JuMP.set_silent(model)
 
     # Get the vertices and edges of `g`.
-    V = vertices(g)
-    E = edges(g)
+    V = Graphs.vertices(g)
+    E = Graphs.edges(g)
 
     # Decision variable for each vertex and color.
     @variable(model, x[V, V], Bin)

--- a/src/Invariants/cliques/clique_number.jl
+++ b/src/Invariants/cliques/clique_number.jl
@@ -22,7 +22,7 @@ function compute(
     ::Type{CliqueNumber},
     g::AbstractGraph{T};
     optimizer=HiGHS.Optimizer,
-) where T <: Int
+) where T <: Integer
     h = complement(g)
     return compute(IndependenceNumber, h; optimizer=optimizer)
 end

--- a/src/Invariants/cliques/maximimum_clique.jl
+++ b/src/Invariants/cliques/maximimum_clique.jl
@@ -34,6 +34,7 @@ function compute(
 
     # Instantiate the model.
     model = Model(optimizer)
+    JuMP.set_silent(model)
 
     n = Graphs.nv(g)
 

--- a/src/Invariants/cliques/maximimum_clique.jl
+++ b/src/Invariants/cliques/maximimum_clique.jl
@@ -35,7 +35,7 @@ function compute(
     # Instantiate the model.
     model = Model(optimizer)
 
-    n = nv(g)
+    n = Graphs.nv(g)
 
     # Decision variable for each vertex.
     @variable(model, x[1:n], Bin)

--- a/src/Invariants/cliques/maximimum_clique.jl
+++ b/src/Invariants/cliques/maximimum_clique.jl
@@ -30,7 +30,7 @@ function compute(
     ::Type{MaximumClique},
     g::AbstractGraph{T};
     optimizer=HiGHS.Optimizer
-) where T
+) where T <: Integer
 
     # Instantiate the model.
     model = Model(optimizer)

--- a/src/Invariants/degree_sequence_invariants/annihilation.jl
+++ b/src/Invariants/degree_sequence_invariants/annihilation.jl
@@ -8,8 +8,8 @@ Return the annihilation number of the graph `g`.
 """
 function compute(
     ::Type{AnnihilationNumber},
-    g::SimpleGraph,
-)
+    g::SimpleGraph{T},
+) where T <: Integer
     # Sort in non-decreasing order
     D = sort(degree(g))
 

--- a/src/Invariants/degree_sequence_invariants/annihilation.jl
+++ b/src/Invariants/degree_sequence_invariants/annihilation.jl
@@ -1,6 +1,4 @@
 
-
-
 """
     compute(::Type{AnnihilationNumber}, g::SimpleGraph)
 
@@ -11,12 +9,15 @@ function compute(
     g::SimpleGraph{T},
 ) where T <: Integer
     # Sort in non-decreasing order
-    D = sort(degree(g))
+    D = sort(Graphs.degree(g))
 
     # The number of edges in `g`.
-    m = ne(g)
+    m = Graphs.ne(g)
 
-    for i in reverse(1:nv(g))
+    # The number of vertices in `g`.
+    n = Graphs.nv(g)
+
+    for i in reverse(1:n)
         if sum(D[1:i]) <= m
             return i
         end

--- a/src/Invariants/degree_sequence_invariants/havel_hakimi_residue.jl
+++ b/src/Invariants/degree_sequence_invariants/havel_hakimi_residue.jl
@@ -1,7 +1,7 @@
 
 function compute(
     ::Type{HavelHakimiResidue},
-    g::AbstractGraph{T}
+    g::SimpleGraph{T}
 ) where T <: Integer
 
     # Get the degree sequence of `g`.

--- a/src/Invariants/degree_sequence_invariants/havel_hakimi_residue.jl
+++ b/src/Invariants/degree_sequence_invariants/havel_hakimi_residue.jl
@@ -5,7 +5,7 @@ function compute(
 ) where T <: Integer
 
     # Get the degree sequence of `g`.
-    sequence = degree(g)
+    sequence = Graphs.degree(g)
 
     # Sort the degree sequence in descending order.
     sort!(sequence, rev=true)

--- a/src/Invariants/degree_sequence_invariants/slater.jl
+++ b/src/Invariants/degree_sequence_invariants/slater.jl
@@ -12,7 +12,7 @@ arXiv preprint arXiv:1611.02379, (2016)
 """
 function compute(
     alg::SubKDominationNumber,
-    g::AbstractGraph{T},
+    g::SimpleGraph{T},
 ) where T <: Integer
 
     # Sort in non-increasing order
@@ -39,8 +39,8 @@ Return the Slater invariant for the graph `g`.
 """
 function compute(
     ::Type{SlaterNumber},
-    g::AbstractGraph{T},
-) where T <: Int
+    g::SimpleGraph{T},
+) where T <: Integer
 
     return compute(SubKDominationNumber(1), g)
 end
@@ -56,7 +56,7 @@ R. Davila, "A note on sub-total domination in graphs", arXiv preprint arXiv:1701
 """
 function compute(
     ::Type{SubTotalDominationNumber},
-    g::AbstractGraph{T},
+    g::SimpleGraph{T},
 ) where T <: Integer
     D = sort(degree(g), rev=true)  # Sort in non-increasing order
     n = nv(g)

--- a/src/Invariants/degree_sequence_invariants/slater.jl
+++ b/src/Invariants/degree_sequence_invariants/slater.jl
@@ -19,7 +19,7 @@ function compute(
     D = sort(degree(g), rev=true)
 
     # The number of vertices in `g`.
-    n = nv(g)
+    n = Graphs.nv(g)
 
     # The sub-k-domination number of `g` is the smallest integer `t` such that
     # the sum of the degrees of the first `t` vertices in the sorted
@@ -58,8 +58,8 @@ function compute(
     ::Type{SubTotalDominationNumber},
     g::SimpleGraph{T},
 ) where T <: Integer
-    D = sort(degree(g), rev=true)  # Sort in non-increasing order
-    n = nv(g)
+    D = sort(Graphs.degree(g), rev=true)  # Sort in non-increasing order
+    n = Graphs.nv(g)
     for i in 1:n
         if sum(D[1:i]) >= n
             return i

--- a/src/Invariants/domination/domination_numbers.jl
+++ b/src/Invariants/domination/domination_numbers.jl
@@ -1,5 +1,5 @@
 """
-    compute(::Type{DominationNumber}, g::AbstractGraph; optimizer=HiGHS.Optimizer)})
+    compute(::Type{DominationNumber}, g::SimpleGraph; optimizer=HiGHS.Optimizer)})
 
 Return the [domination number](https://en.wikipedia.org/wiki/Dominating_set) of `g`.
 
@@ -26,15 +26,15 @@ julia> compute(DominationNumber, g)
 """
 function compute(
     ::Type{DominationNumber},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer=HiGHS.Optimizer
-) where T <: Int
+) where T <: Integer
     min_tds = compute(MinimumDominatingSet, g; optimizer=optimizer)
     return length(min_tds.nodes)
 end
 
 """
-    compute(::Type{TotalDominationNumber}, g::AbstractGraph{T}; optimizer=HiGHS.Optimizer)
+    compute(::Type{TotalDominationNumber}, g::SimpleGraph{T}; optimizer=HiGHS.Optimizer)
 
 Return the [total domination number](https://en.wikipedia.org/wiki/Total_dominating_set) of `g`.
 
@@ -60,9 +60,9 @@ julia> compute(TotalDominationNumber, g)
 """
 function compute(
     ::Type{TotalDominationNumber},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer=HiGHS.Optimizer
-) where T <: Int
+) where T <: Integer
     min_tds = compute(MinimumTotalDominatingSet, g; optimizer=optimizer)
     return length(min_tds.nodes)
 end
@@ -70,9 +70,9 @@ end
 
 function compute(
     ::Type{LocatingDominationNumber},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer=HiGHS.Optimizer
-) where T <: Int
+) where T <: Integer
     min_tds = compute(MinimumLocatingDominatingSet, g; optimizer=optimizer)
     return length(min_tds.nodes)
 end
@@ -80,15 +80,15 @@ end
 
 function compute(
     ::Type{PairedDominationNumber},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer=HiGHS.Optimizer
-) where T <: Int
+) where T <: Integer
     min_tds = compute(MinimumPairedDominatingSet, g; optimizer=optimizer)
     return length(min_tds.nodes)
 end
 
 """
-    compute(::Type{IndependentDominationNumber}, g::AbstractGraph{T}; optimizer=HiGHS.Optimizer)
+    compute(::Type{IndependentDominationNumber}, g::SimpleGraph{T}; optimizer=HiGHS.Optimizer)
 
 Return the [independent domination number](https://en.wikipedia.org/wiki/Independent_dominating_set) of `g`.
 
@@ -114,15 +114,15 @@ julia> compute(IndependentDominationNumber, g)
 """
 function compute(
     ::Type{IndependentDominationNumber},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer=HiGHS.Optimizer
-) where T <: Int
+) where T <: Integer
     min_tds = compute(MinimumIndependentDominatingSet, g; optimizer=optimizer)
     return length(min_tds.nodes)
 end
 
 """
-    compute(::Type{EdgeDominationNumber}, g::AbstractGraph{T}; optimizer=HiGHS.Optimizer)
+    compute(::Type{EdgeDominationNumber}, g::SimpleGraph{T}; optimizer=HiGHS.Optimizer)
 
 Return the [edge domination number](https://en.wikipedia.org/wiki/Edge_dominating_set) of `g`.
 
@@ -148,23 +148,23 @@ julia> compute(EdgeDominationNumber, g)
 """
 function compute(
     ::Type{EdgeDominationNumber},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer=HiGHS.Optimizer
-) where T <: Int
+) where T <: Integer
     min_tds = compute(MinimumEdgeDominatingSet, g; optimizer=optimizer)
     return length(min_tds.edges)
 end
 
 """
-    compute(::Type{PowerDominationNumber}, g::AbstractGraph{T})
+    compute(::Type{PowerDominationNumber}, g::SimpleGraph{T})
 
 Return the [power domination number](https://en.wikipedia.org/wiki/Power_dominating_set) of `g`.
 
 """
 function compute(
     ::Type{PowerDominationNumber},
-    g::AbstractGraph{T}
-) where T <: Int
+    g::SimpleGraph{T}
+) where T <: Integer
     min_pds = compute(MinimumPowerDominatingSet, g)
     return length(min_pds.nodes)
 end

--- a/src/Invariants/domination/minimum_dominating_sets.jl
+++ b/src/Invariants/domination/minimum_dominating_sets.jl
@@ -38,7 +38,7 @@ function compute(
     JuMP.set_silent(model)
 
     # The number of vertices.
-    n = nv(g)
+    n = Graphs.nv(g)
 
     # Decision variable for each vertex.
     @variable(model, x[1:n], Bin)
@@ -101,7 +101,7 @@ function compute(
     JuMP.set_silent(model)
 
     # The number of vertices.
-    n = nv(g)
+    n = Graphs.nv(g)
 
     # Decision variable for each vertex.
     @variable(model, x[1:n], Bin)
@@ -111,7 +111,7 @@ function compute(
 
     # Constraints: each vertex must either be in the dominating set or adjacent to a vertex in the set
     for u in 1:n
-        neighbors_u = neighbors(g, u)
+        neighbors_u = Graphs.neighbors(g, u)
         @constraint(model, sum(x[v] for v in neighbors_u) >= 1)
     end
 
@@ -176,7 +176,7 @@ function compute(
     model = Model(optimizer)
     JuMP.set_silent(model)
 
-    n = nv(g)
+    n = Graphs.nv(g)
 
     # Decision variable for each vertex.
     @variable(model, x[1:n], Bin)
@@ -220,7 +220,7 @@ function compute(
     JuMP.set_silent(model)
 
     # The number of vertices.
-    n = nv(g)
+    n = Graphs.nv(g)
 
     # Decision variable for each vertex.
     @variable(model, x[1:n], Bin)
@@ -230,14 +230,14 @@ function compute(
 
     # Constraints: each vertex must either be in the dominating set or adjacent to a vertex in the set
     for u in 1:n
-        neighbors_u = neighbors(g, u)
+        neighbors_u = Graphs.neighbors(g, u)
         @constraint(model, x[u] + sum(x[v] for v in neighbors_u) >= 1)
     end
 
     # Constraints: insure that no two vertices in the dominating set are adjacent
     for u in 1:n
         for v in (u+1):n
-            if has_edge(g, u, v)
+            if Graphs.has_edge(g, u, v)
                 @constraint(model, x[u] + x[v] <= 1)
             end
         end
@@ -264,7 +264,7 @@ function compute(
     JuMP.set_silent(model)
 
     # The edge set of the graph.
-    E = edges(g)
+    E = Graphs.edges(g)
 
     # Decision variable for each edge.
     @variable(model, x[E], Bin)
@@ -274,7 +274,7 @@ function compute(
 
     # Constraints: Each edge or at least one of its adjacent edges is in the MEDS
     for e in E
-        u, v = src(e), dst(e)
+        u, v = Graphs.src(e), Graphs.dst(e)
         adjacent_edges = [
             e2 for e2 in E
             if (e2 != e) &&
@@ -306,9 +306,12 @@ function compute(
     ::Type{MinimumPowerDominatingSet},
     g::AbstractGraph{T}
 ) where T <: Int
-    n = nv(g)
+
+    # The number of vertices.
+    n = Graphs.nv(g)
+
     for size in 1:n
-        for subset in combinations(1:n, size)
+        for subset in Combinatorics.combinations(1:n, size)
             blue = Set(subset)
             apply!(DominationRule, blue, g)
             apply!(ZeroForcingRule, blue, g; max_iter=n)

--- a/src/Invariants/drawing/draw_optimal_sets.jl
+++ b/src/Invariants/drawing/draw_optimal_sets.jl
@@ -3,7 +3,7 @@ function draw_optimal_set(
     optset::AbstractOptimalNodeSet
 )
     # Create a default color array filled with blue for each node
-    nodecolors = [colorant"lightblue" for _ in 1:nv(g)]
+    nodecolors = [colorant"lightblue" for _ in 1:Graphs.nv(g)]
 
     # Update the color for nodes that are in the optimal set
     for node in optset.nodes
@@ -14,7 +14,7 @@ function draw_optimal_set(
     gplot(
         g,
         nodefillc=nodecolors,
-        nodelabel=vertices(g),
+        nodelabel=Graphs.vertices(g),
         layout=stressmajorize_layout
     )
 end

--- a/src/Invariants/drawing/draw_optimal_sets.jl
+++ b/src/Invariants/drawing/draw_optimal_sets.jl
@@ -1,4 +1,7 @@
-function draw_optimal_set(g::AbstractGraph, optset::AbstractOptimalNodeSet)
+function draw_optimal_set(
+    g::AbstractGraph,
+    optset::AbstractOptimalNodeSet
+)
     # Create a default color array filled with blue for each node
     nodecolors = [colorant"lightblue" for _ in 1:nv(g)]
 

--- a/src/Invariants/independence/independence_number.jl
+++ b/src/Invariants/independence/independence_number.jl
@@ -1,7 +1,7 @@
 @doc raw"""
     function compute(
         ::Type{CliqueNumber},
-        g::AbstractGraph{T};
+        g::SimpleGraph{T};
         optimizer=Cbc.Optimizer,
     ) where T <: Integer
 
@@ -24,7 +24,7 @@ julia> compute(IndependenceNumber, g)
 """
 function compute(
     ::Type{IndependenceNumber},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer=HiGHS.Optimizer,
 ) where T <: Integer
     max_ind_set = compute(MaximumIndependentSet, g; optimizer=optimizer)

--- a/src/Invariants/independence/max_independent_set.jl
+++ b/src/Invariants/independence/max_independent_set.jl
@@ -42,22 +42,28 @@ function compute(
     model = Model(optimizer)  # You can replace Cbc with your preferred optimizer
     JuMP.set_silent(model)  # Suppress solver output
 
+    # The vertex set.
+    V = Graphs.vertices(g)
+
+    # The edge set.
+    E = Graphs.edges(g)
+
     # Define binary variables for each vertex
-    @variable(model, x[vertices(g)], Bin)
+    @variable(model, x[V], Bin)
 
     # Define the objective function
-    @objective(model, Max, sum(x[v] for v in vertices(g)))
+    @objective(model, Max, sum(x[v] for v in V))
 
     # Add constraints: adjacent vertices cannot both be in the independent set
-    for e in edges(g)
-        @constraint(model, x[src(e)] + x[dst(e)] <= 1)
+    for e in E
+        @constraint(model, x[Graphs.src(e)] + x[Graphs.dst(e)] <= 1)
     end
 
     # Solve the optimization problem
     optimize!(model)
 
     # Extract the solution
-    independent_set = [v for v in vertices(g) if value(x[v]) == 1.0]
+    independent_set = [v for v in V if value(x[v]) == 1.0]
 
     return MaximumIndependentSet(independent_set)
 end

--- a/src/Invariants/independence/max_independent_set.jl
+++ b/src/Invariants/independence/max_independent_set.jl
@@ -35,7 +35,7 @@ julia> compute(MaximumIndependentSet, g)
 """
 function compute(
     ::Type{MaximumIndependentSet},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer=HiGHS.Optimizer,
 ) where T <: Integer
 

--- a/src/Invariants/matching/matching_number.jl
+++ b/src/Invariants/matching/matching_number.jl
@@ -25,7 +25,7 @@ function compute(
     ::Type{MatchingNumber},
     g::SimpleGraph{T};
     optimizer=HiGHS.Optimizer
-) where T <: Int
+) where T <: Integer
     max_ms = compute(MaximumMatching, g; optimizer=optimizer)
     return length(max_ms.edges)
 end

--- a/src/Invariants/matching/matching_sets.jl
+++ b/src/Invariants/matching/matching_sets.jl
@@ -1,6 +1,6 @@
 
 """
-    compute(::Type{MaximumMatching}, g::AbstractGraph{T}; optimizer=HiGHS.Optimizer) where T <: Integer
+    compute(::Type{MaximumMatching}, g::SimpleGraph{T}; optimizer=HiGHS.Optimizer) where T <: Integer
 
 Return a maximum matching of `g`.
 
@@ -28,7 +28,7 @@ julia> compute(MaximumMatching, g)
 """
 function compute(
     ::Type{MaximumMatching},
-    g::AbstractGraph{T};
+    g::SimpleGraph{T};
     optimizer=HiGHS.Optimizer
 ) where T <: Integer
     # Instantiate the model.

--- a/src/Invariants/matching/matching_sets.jl
+++ b/src/Invariants/matching/matching_sets.jl
@@ -36,10 +36,10 @@ function compute(
     JuMP.set_silent(model)
 
     # The number of vertices.
-    n = nv(g)
+    n = Graphs.nv(g)
 
     # The edge set of the graph.
-    E = edges(g)
+    E = Graphs.edges(g)
 
     # Decision variable for each edge.
     @variable(model, x[E], Bin)
@@ -49,7 +49,7 @@ function compute(
 
     # Constraints: Each vertex is incident to at most one matched edge
     for v in 1:n
-        incident_edges = [e for e in E if src(e) == v || dst(e) == v]
+        incident_edges = [e for e in E if Graphs.src(e) == v || Graphs.dst(e) == v]
         @constraint(model, sum(x[e] for e in incident_edges) <= 1)
     end
 

--- a/src/Invariants/zero_forcing/minimum_zero_forcing_set.jl
+++ b/src/Invariants/zero_forcing/minimum_zero_forcing_set.jl
@@ -8,9 +8,12 @@ function compute(
     ::Type{MinimumZeroForcingSet},
     g::SimpleGraph{T}
 ) where T <: Integer
-    n = nv(g)
+
+    # Get the number of vertices in `g`.
+    n = Graphs.nv(g)
+
     for size in 1:n
-        for subset in combinations(1:n, size)
+        for subset in Combinatorics.combinations(1:n, size)
             blue = Set(subset)
             apply!(ZeroForcingRule, blue, g; max_iter=n)
             if length(blue) == n

--- a/src/Invariants/zero_forcing/minimum_zero_forcing_set.jl
+++ b/src/Invariants/zero_forcing/minimum_zero_forcing_set.jl
@@ -6,8 +6,8 @@ Return a minimum zero forcing set of `g`.
 """
 function compute(
     ::Type{MinimumZeroForcingSet},
-    g::AbstractGraph
-)
+    g::SimpleGraph{T}
+) where T <: Integer
     n = nv(g)
     for size in 1:n
         for subset in combinations(1:n, size)

--- a/src/Invariants/zero_forcing/zero_forcing_number.jl
+++ b/src/Invariants/zero_forcing/zero_forcing_number.jl
@@ -6,7 +6,7 @@ Return the zero forcing number of `g`.
 """
 function compute(
     ::Type{ZeroForcingNumber},
-    g::AbstractGraph{T}
+    g::SimpleGraph{T}
 ) where T <: Integer
     opt_set = compute(MinimumZeroForcingSet, g)
     return length(opt_set.nodes)


### PR DESCRIPTION
### Summary of Changes
This PR introduces a series of updates within the Invariants module of the `GraphProperties.jl` package, with the intent to enhance consistency, maintainability, and performance by leveraging the specific functions from the `Graphs.jl` package and narrowing the function scope to `SimpleGraph` types.

### Modifications
* **Explicit Namespace Usage:** Functions previously called directly (e.g., `degree(g)`) are now explicitly referenced with the Graphs namespace (e.g., `Graphs.degree(g)`). _This change ensures that there is no ambiguity in function calls_, especially if there are multiple methods available for different graph types or from different modules.
* **Type Restriction:** The module's compute functions were initially designed to work with the more general `AbstractGraph{T}` type. This PR restricts the scope of these functions to `SimpleGraph{T}`, which provides a clearer and more targeted implementation, potentially optimizing performance and improving readability.

### Testing
No testing has been added, but will need to be added in a subsequent PR. 

### Notes for Reviewers
Reviewers are encouraged to focus on the implications of restricting compute functions to `SimpleGraph{T}` and the explicit use of the `Graphs.jl` namespace for clarity. Any feedback on potential overlooked edge cases or architectural concerns would be highly appreciated.