### PR TITLE
Properties: is_triangle / bull / claw_free

### DIFF
--- a/src/Basics/Basics.jl
+++ b/src/Basics/Basics.jl
@@ -4,12 +4,16 @@ using Graphs
 
 include(joinpath(@__DIR__, "diameter.jl"))
 include(joinpath(@__DIR__, "girth.jl"))
+include(joinpath(@__DIR__, "is_free.jl"))
 include(joinpath(@__DIR__, "radius.jl"))
 include(joinpath(@__DIR__, "size.jl"))
 include(joinpath(@__DIR__, "order.jl"))
 
 export diameter
 export girth
+export is_bull_free
+export is_claw_free
+export is_triangle_free
 export radius
 export size
 export order

--- a/src/Basics/is_free.jl
+++ b/src/Basics/is_free.jl
@@ -6,15 +6,15 @@ Return `true` if `G` is triangle-free, and `false` otherwise.
 function is_triangle_free(G::SimpleGraph{T}) where T <: Integer
 
     # iterate over edges
-    for e in edges(G)
+    for e in Graphs.edges(G)
 
         # extract incident nodes
-        e isa SimpleEdge && (u, v = e.src, e.dst)
+        e isa Graphs.SimpleEdge && ((u, v) = (e.src, e.dst))
         e isa Tuple && (u, v = e)
 
         # if the nodes share a neighbor, return false
-        for w in neighbors(G, u)
-            w != v && has_edge(G, w, v) && return false
+        for w in Graphs.neighbors(G, u)
+            w != v && Graphs.has_edge(G, w, v) && return false
         end
     end
 
@@ -30,28 +30,30 @@ Return `true` if no induced subgraph of `G` is a bull, and `false` otherwise.
 function is_bull_free(G::SimpleGraph{T}) where T <: Integer
 
     # iterate over edges
-    for e in edges(G)
+    for e in Graphs.edges(G)
 
         # extract incident nodes
-        e isa SimpleEdge && (u, v = e.src, e.dst)
+        e isa Graphs.SimpleEdge && ((u, v) = (e.src, e.dst))
         e isa Tuple && (u, v = e)
 
         # if the nodes share a neighbor, examine triangle for bullhorns
-        for w in neighbors(G, u)
-            if w != v && has_edge(G, w, v)
+        for w in Graphs.neighbors(G, u)
+            if w != v && Graphs.has_edge(G, w, v)
 
                 # check if u and v have disjoint edges, and that the subgraph is induced
                 for x in Graphs.neighbors(G,u)
-                    if !has_edge(G, x, v) && !has_edge(G, x, w)
+                    if !Graphs.has_edge(G, x, v) && !Graphs.has_edge(G, x, w)
                         for y in Graphs.neighbors(G,v)
-                            has_edge(G, y, u) || has_edge(G, y, w) || \
-                            has_edge(G, y, x) || return false
+                            Graphs.has_edge(G, y, u) || Graphs.has_edge(G, y, w) || \
+                            Graphs.has_edge(G, y, x) || return false
                         end
                     end
                 end
             end
         end
     end
+
+    return true
 end
 
 """
@@ -62,17 +64,17 @@ Return `true` if no induced subgraph of `G` is a claw, and `false` otherwise.
 function is_claw_free(G::SimpleGraph{T}) where T <: Integer
 
     # iterate over possible center of the stars
-    for v in vertices(G)
-        degree(G, v) >= 3 || continue
+    for v in Graphs.vertices(G)
+        Graphs.degree(G, v) >= 3 || continue
 
         # find neighbors v, w, and x of v and check for claw
-        v_neighbors = Set(neighbors(G, v))
-        for u in neighbors(G, v)
+        v_neighbors = Set(Graphs.neighbors(G, v))
+        for u in Graphs.neighbors(G, v)
             for w in v_neighbors
-                if u != w && !has_edge(G, u, w)
+                if u != w && !Graphs.has_edge(G, u, w)
                     for x in v_neighbors
-                        x == u || x == w || has_edge(G, u, x) || \ 
-                        has_edge(G, w, x) || return false
+                        x == u || x == w || Graphs.has_edge(G, u, x) || \ 
+                        Graphs.has_edge(G, w, x) || return false
                     end
                 end
             end
@@ -81,4 +83,6 @@ function is_claw_free(G::SimpleGraph{T}) where T <: Integer
             delete!(v_neighbors, u)
         end
     end
+
+    return true
 end

--- a/src/Basics/is_free.jl
+++ b/src/Basics/is_free.jl
@@ -1,0 +1,84 @@
+"""
+    is_triangle_free(G::SimpleGraph{T})
+
+Return `true` if `G` is triangle-free, and `false` otherwise.
+"""
+function is_triangle_free(G::SimpleGraph{T}) where T <: Integer
+
+    # iterate over edges
+    for e in edges(G)
+
+        # extract incident nodes
+        e isa SimpleEdge && (u, v = e.src, e.dst)
+        e isa Tuple && (u, v = e)
+
+        # if the nodes share a neighbor, return false
+        for w in neighbors(G, u)
+            w != v && has_edge(G, w, v) && return false
+        end
+    end
+
+    # if no triangles found, return true
+    return true
+end
+
+"""
+    is_bull_free(G::SimpleGraph{T})
+
+Return `true` if no induced subgraph of `G` is a bull, and `false` otherwise.
+"""
+function is_bull_free(G::SimpleGraph{T}) where T <: Integer
+
+    # iterate over edges
+    for e in edges(G)
+
+        # extract incident nodes
+        e isa SimpleEdge && (u, v = e.src, e.dst)
+        e isa Tuple && (u, v = e)
+
+        # if the nodes share a neighbor, examine triangle for bullhorns
+        for w in neighbors(G, u)
+            if w != v && has_edge(G, w, v)
+
+                # check if u and v have disjoint edges, and that the subgraph is induced
+                for x in Graphs.neighbors(G,u)
+                    if !has_edge(G, x, v) && !has_edge(G, x, w)
+                        for y in Graphs.neighbors(G,v)
+                            has_edge(G, y, u) || has_edge(G, y, w) || \
+                            has_edge(G, y, x) || return false
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+
+"""
+    is_claw_free(G::SimpleGraph{T})
+
+Return `true` if no induced subgraph of `G` is a claw, and `false` otherwise.
+"""
+function is_claw_free(G::SimpleGraph{T}) where T <: Integer
+
+    # iterate over possible center of the stars
+    for v in vertices(G)
+        degree(G, v) >= 3 || continue
+
+        # find neighbors v, w, and x of v and check for claw
+        v_neighbors = Set(neighbors(G, v))
+        for u in neighbors(G, v)
+            for w in v_neighbors
+                if u != w && !has_edge(G, u, w)
+                    for x in v_neighbors
+                        x == u || x == w || has_edge(G, u, x) || \ 
+                        has_edge(G, w, x) || return false
+                    end
+                end
+            end
+
+            # if no claws were foudn with u, don't check it again
+            delete!(v_neighbors, u)
+        end
+    end
+end

--- a/test/Basics/basics_tests.jl
+++ b/test/Basics/basics_tests.jl
@@ -75,10 +75,10 @@
     end
 
     @testset "order" begin
-        @test order(g_2) == 5
-        @test order(g_3) == 8
-        @test order(g_4) == 5
-        @test order(g_5) == 9
+        @test GraphProperties.Basics.order(g_2) == 5
+        @test GraphProperties.Basics.order(g_3) == 8
+        @test GraphProperties.Basics.order(g_4) == 5
+        @test GraphProperties.Basics.order(g_5) == 9
     end
 
     @testset "size" begin

--- a/test/Basics/basics_tests.jl
+++ b/test/Basics/basics_tests.jl
@@ -1,0 +1,90 @@
+@testset "GraphProperties.Basics.jl" begin
+    # create graphs to test basics:
+        # 1) empty graph - we ignore this case
+        # 2) complete 5 graph
+        # 3) graph with 1 claw and 1 bull
+        # 4) bipartite K_2,3 graph
+        # 5) C_9 graph
+
+    # g_1 = Graphs.SimpleGraph(0) # we ignore this case
+
+    g_2 = Graphs.complete_graph(5)
+
+    g_3 = Graphs.SimpleGraph(8)
+    add_edge!(g_3, 1, 2)
+    add_edge!(g_3, 1, 3)
+    add_edge!(g_3, 1, 4)
+    add_edge!(g_3, 1, 5)
+    add_edge!(g_3, 1, 6)
+    add_edge!(g_3, 2, 4)
+    add_edge!(g_3, 2, 7)
+    add_edge!(g_3, 4, 8)
+
+    g_4 = Graphs.SimpleGraph(5)
+    for i in 1:3
+        for j in 4:5
+            add_edge!(g_4, i, j)
+        end
+    end
+
+    g_5 = Graphs.SimpleGraph(9)
+    for i in 1:9
+        add_edge!(g_5, i, (i % 9) + 1)
+    end
+
+    @testset "diameter" begin
+        @test diameter(g_2) == 1
+        @test diameter(g_3) == 3
+        @test diameter(g_4) == 2
+        @test diameter(g_5) == 4
+    end
+
+    @testset "radius" begin
+        @test radius(g_2) == 1
+        @test radius(g_3) == 2
+        @test radius(g_4) == 2
+        @test radius(g_5) == 4
+    end
+
+    @testset "girth" begin
+        @test girth(g_2) == 3
+        @test girth(g_3) == 3
+        @test girth(g_4) == 4
+        @test girth(g_5) == 9
+    end
+
+    @testset "is_triangle_free" begin
+        @test is_triangle_free(g_2) == false
+        @test is_triangle_free(g_3) == false
+        @test is_triangle_free(g_4) == true
+        @test is_triangle_free(g_5) == true
+    end
+
+    @testset "is_claw_free" begin
+        @test is_claw_free(g_2) == true
+        @test is_claw_free(g_3) == false
+        @test is_claw_free(g_4) == false
+        @test is_claw_free(g_5) == true
+    end
+
+    @testset "is_bull_free" begin
+        @test is_bull_free(g_2) == true
+        @test is_bull_free(g_3) == false
+        @test is_bull_free(g_4) == true
+        @test is_bull_free(g_5) == true
+    end
+
+    @testset "order" begin
+        @test order(g_2) == 5
+        @test order(g_3) == 8
+        @test order(g_4) == 5
+        @test order(g_5) == 9
+    end
+
+    @testset "size" begin
+        @test size(g_2) == 10
+        @test size(g_3) == 8
+        @test size(g_4) == 6
+        @test size(g_5) == 9
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,7 @@ end
 @testset "GraphProperties.Basics.jl Tests" begin
     using Graphs
     using GraphProperties
-    using GraphProperties.Basics: diameter, girth, is_bull_free, is_claw_free, is_triangle_free, radius, size
+    using GraphProperties.Basics: diameter, girth, is_bull_free, is_claw_free, is_triangle_free, order, radius, size
 
     include(joinpath(@__DIR__, "Basics","basics_tests.jl"))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,3 +16,11 @@ end
 
     include(joinpath(@__DIR__, "GraphIO","graphio_tests.jl"))
 end
+
+@testset "GraphProperties.Basics.jl Tests" begin
+    using Graphs
+    using GraphProperties
+    using GraphProperties.Basics: diameter, girth, is_bull_free, is_claw_free, is_triangle_free, radius, size
+
+    include(joinpath(@__DIR__, "Basics","basics_tests.jl"))
+end


### PR DESCRIPTION
# Description
I added is_triangle_free, is_bull_free, and is_claw_free to Basics and added tests for Basics including these properties.
tests for the trivial zero-order graph are left out.

is_[structure]_free checks if there are any **induced** subgraphs that are a [structure]. An induced subgraph includes all edges between the included nodes. A triangle is K_3, a bull is a triangle with two disjoint edges adjacent to the triangle, a claw is the star, S_3.


### Documentation and Style

- [X] I have added docstrings to any new functions or types, as applicable.
- [X] My code follows the project's coding style and guidelines.
- [X] If you have added a new algorithm or function, you have also included corresponding unit tests.
- [X] I confirm that any code added is my own work and is not copied from other sources.
- [X] I have requested a review from at least one other contributor.

### Developer's Declaration:

By submitting this Pull Request, I confirm the following:

- [X] The code I am submitting is my own work and I have the rights to use and distribute it.
- [X] I confirm that the code I have added is not copied from other sources and that I have appropriately cited or acknowledged any external code or references used.
- [X] I understand that my code will be reviewed and any changes requested must be addressed.

### PR Type

What kind of change does this PR introduce?
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [X] Unit Testing
- [ ] Other... Please describe:
